### PR TITLE
fix typo & delete debug_backtrace

### DIFF
--- a/src/SQSLogger.php
+++ b/src/SQSLogger.php
@@ -93,14 +93,10 @@ class SQSLogger
             $id = auth()->user()->id;
         }
 
-        $bt = debug_backtrace();
-
         $body = [
             'level' => $level,
             'time' => date('Y-m-d H:i:s'),
             'userId' => $id,
-            'file' => $bt[1]['file'],
-            'line' => $bt[1]['line'],
             'message' => $message
         ];
 

--- a/src/SQSLogger.php
+++ b/src/SQSLogger.php
@@ -37,7 +37,7 @@ class SQSLogger
     {
         $info = ['method' => $request->method(), 'accessUrl' => $request->fullUrl()];
 
-        if (!is_null($extrainfo)) {
+        if (!is_null($extraInfo)) {
             $info += $extraInfo;
         }
 


### PR DESCRIPTION
#5 
debug_backtraceは、SQSLoggerが呼び出されるタイミングがわからないので、ユーザーがextraInfoとして追加したほうが良いと判断しました。